### PR TITLE
tensorboard-data-server-feedstock 0.7.2

### DIFF
--- a/recipe/0002-do-not-use-platform-tag.patch
+++ b/recipe/0002-do-not-use-platform-tag.patch
@@ -1,0 +1,13 @@
+diff --git a/tensorboard/data/server/pip_package/build.py b/tensorboard/data/server/pip_package/build.py
+index 72a71ffb80..c3e92f5b73 100644
+--- a/tensorboard/data/server/pip_package/build.py
++++ b/tensorboard/data/server/pip_package/build.py
+@@ -100,7 +100,7 @@ def main():
+
+     os.chdir(tmpdir)
+     subprocess.run(
+-        [sys.executable, "setup.py", "bdist_wheel", "-p", platform_tag],
++        [sys.executable, "setup.py", "bdist_wheel"],
+         stdout=sys.stderr,
+         check=True,
+     )

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -12,7 +12,13 @@ if [[ "${target_platform}" == "linux-64" ]] || [[ "${target_platform}" == osx-* 
   cargo build --release
 
   pushd pip_package
-  $PYTHON build.py --out-dir="$SRC_DIR/" --server-binary=../target/release/rustboard
+  # Upstream defaults to manylinux_2_31 (Ubuntu 20.04). Conda's linux sysroot uses
+  # glibc 2.28, so pip rejects that wheel tag during install ("not a supported wheel").
+  if [[ "${target_platform}" == linux-* ]]; then
+    $PYTHON build.py --out-dir="$SRC_DIR/" --server-binary=../target/release/rustboard --platform manylinux_2_28
+  else
+    $PYTHON build.py --out-dir="$SRC_DIR/" --server-binary=../target/release/rustboard
+  fi
 
   if [[ "${target_platform}" == "osx-arm64" ]]; then
     WHEEL_NAME=$(ls $SRC_DIR/*.whl)

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,12 +20,6 @@ if [[ "${target_platform}" == "linux-64" ]] || [[ "${target_platform}" == osx-* 
     $PYTHON build.py --out-dir="$SRC_DIR/" --server-binary=../target/release/rustboard
   fi
 
-  if [[ "${target_platform}" == "osx-arm64" ]]; then
-    WHEEL_NAME=$(ls $SRC_DIR/*.whl)
-    NEW_WHEEL_NAME=${WHEEL_NAME/macosx_10_9_x86_64/macosx_11_0_arm64}
-    mv $WHEEL_NAME ${NEW_WHEEL_NAME}
-  fi
-
   $PYTHON -m pip install --no-deps --no-build-isolation --ignore-installed -v $SRC_DIR/*.whl
 
 else

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,2 @@
 rust_compiler_version:
-  - 1.64.0
+  - 1.93.1

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,0 @@
-rust_compiler_version:
-  - 1.93.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
 build:
   script_env:
     - WHEELNAME={{ _name }}-{{ version }}-py3-none-any.whl  # [win]
-  number: 4
+  number: 0
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tensorboard-data-server" %}
-{% set version = "0.7.0" %}
+{% set version = "0.7.2" %}
 {% set _name = "tensorboard_data_server" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/tensorflow/tensorboard/archive/refs/tags/data-server-v{{ version }}.tar.gz
-  sha256: 47f0b4edf434cedea351f60ad7ebe63b575cfd103fa19555b404e0e108c364cd
+  sha256: 02a510803df83cc66564964a0087adc6e2aabcb0b7617b7258b80e3115624bdd
   patches:                                               # [win]
     - 0001-Do-not-try-to-remove-tmpdir-on-Windows.patch  # [win]
 
@@ -18,7 +18,7 @@ build:
   skip: True  # [py<37]
   script_env:
     - WHEELNAME={{ _name }}-{{ version }}-py3-none-any.whl  # [win]
-  number: 1
+  number: 0
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,10 +22,9 @@ build:
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+    - python
     - {{ compiler('c') }}  # [not win]
-    - {{ stdlib("c") }}    # [not win]
+    - {{ stdlib('c') }}    # [not win]
     - {{ compiler('rust') }}  # [not win]
   host:
     - python
@@ -42,8 +41,13 @@ test:
 about:
   home: https://github.com/tensorflow/tensorboard
   license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
-  summary: 'Data server for TensorBoard'
+  summary: Data server for TensorBoard
+  description: |
+    Rust-based backend used by TensorBoard to load and serve large log directories
+    efficiently without blocking the Python process.
+  doc_url: https://www.tensorflow.org/tensorboard
   dev_url: https://github.com/tensorflow/tensorboard/tree/master/tensorboard/data/server
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,51 +9,45 @@ package:
 source:
   url: https://github.com/tensorflow/tensorboard/archive/refs/tags/data-server-v{{ version }}.tar.gz
   sha256: 02a510803df83cc66564964a0087adc6e2aabcb0b7617b7258b80e3115624bdd
-  patches:                                               # [win]
+  patches:
     - 0001-Do-not-try-to-remove-tmpdir-on-Windows.patch  # [win]
+    - 0002-do-not-use-platform-tag.patch  # [osx and arm64]
 
 # Windows is currently unsupported, so we build an universal dummy wheel instead for Windows
-# See https://github.com/tensorflow/tensorboard/blob/data-server-v0.7.0/tensorboard/data/server/pip_package/build.py#L39-L43
+# See https://github.com/tensorflow/tensorboard/blob/348af4c/tensorboard/data/server/pip_package/build.py#L78-L86
 build:
-  skip: True  # [py<37]
   script_env:
     - WHEELNAME={{ _name }}-{{ version }}-py3-none-any.whl  # [win]
-  number: 0
+  number: 4
 
 requirements:
   build:
-    - python
-    - {{ compiler('c') }}               # [not win]
-    - {{ compiler('rust') }}            # [not win]
-    - m2-patch                          # [win]
+    - python                                 # [build_platform != target_platform]
+    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+    - {{ compiler('c') }}  # [not win]
+    - {{ stdlib("c") }}    # [not win]
+    - {{ compiler('rust') }}  # [not win]
   host:
     - python
     - pip
-    - openssl                           # [not (win or osx or (linux and x86_64))]
     - setuptools
-    - wheel
+    - openssl  # [not win]
   run:
     - python
 
 test:
   imports:
     - tensorboard_data_server
-  commands:
-    - pip check
-  requires:
-    - pip
 
 about:
   home: https://github.com/tensorflow/tensorboard
   license: Apache-2.0
   license_file: LICENSE
-  license_family: Apache
   summary: 'Data server for TensorBoard'
   dev_url: https://github.com/tensorflow/tensorboard/tree/master/tensorboard/data/server
 
 extra:
   recipe-maintainers:
+    - Carreau
     - mdraw
-  skip-lints:
-    - missing_description
-    - missing_documentation
+    - ngam


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-12179](https://anaconda.atlassian.net/browse/PKG-12179)
- [Upstream repository](https://github.com/tensorflow/tensorboard/tree/data-server-v0.7.2/tensorboard/data/server)

### Explanation of changes:

- New version number
- Update rust compiler version
- Reset build number
- Sync with Conda Forge
-  Upstream defaults to manylinux_2_31 (Ubuntu 20.04). Conda's linux sysroot uses glibc 2.28, so pip rejects that wheel tag during install ("not a supported wheel").


[PKG-12179]: https://anaconda.atlassian.net/browse/PKG-12179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ